### PR TITLE
Fixing typo in asexpr.cc and adding blitz/tv2fastiter.h to expr.h so …

### DIFF
--- a/blitz/array/asexpr.cc
+++ b/blitz/array/asexpr.cc
@@ -29,7 +29,7 @@
  *
  ***************************************************************************/
 #ifndef BZ_ASEXPR_CC
-#define BZ_ASEXPR_cc
+#define BZ_ASEXPR_CC
 
 #include <blitz/array/asexpr.h>
 #include <blitz/array-impl.h>

--- a/blitz/array/expr.h
+++ b/blitz/array/expr.h
@@ -37,6 +37,7 @@
 #include <blitz/array/domain.h>
 #include <blitz/array/slice.h>
 #include <blitz/bounds.h>
+#include <blitz/tv2fastiter.h> 
 
 /*
  * The array expression templates iterator interface is followed by


### PR DESCRIPTION
…that it compiles when -DBZ_DEBUG is on.  These errors occur using clang on OS X