### PR TITLE
Changes for CLang on Mac OS X

### DIFF
--- a/blitz/bzdebug.h
+++ b/blitz/bzdebug.h
@@ -117,15 +117,15 @@ _bz_global int  assertSuccessCount BZ_GLOBAL_INIT(0);
     }
   }
 
-    #define BZASSERT(X)        checkAssert(X, __FILE__, __LINE__)
-    #define BZPRECONDITION(X)  checkAssert(X, __FILE__, __LINE__)
-    #define BZPOSTCONDITION(X) checkAssert(X, __FILE__, __LINE__)
-    #define BZSTATECHECK(X,Y)  checkAssert(X == Y, __FILE__, __LINE__)
+    #define BZASSERT(X)        blitz::checkAssert(X, __FILE__, __LINE__)
+    #define BZPRECONDITION(X)  blitz::checkAssert(X, __FILE__, __LINE__)
+    #define BZPOSTCONDITION(X) blitz::checkAssert(X, __FILE__, __LINE__)
+    #define BZSTATECHECK(X,Y)  blitz::checkAssert(X == Y, __FILE__, __LINE__)
     #define BZPRECHECK(X,Y)                                    \
         {                                                      \
             if ((assertFailMode == false) && (!(X)))           \
                 BZ_STD_SCOPE(cerr) << Y << BZ_STD_SCOPE(endl); \
-            checkAssert(X, __FILE__, __LINE__);                \
+            blitz::checkAssert(X, __FILE__, __LINE__);         \
         }
 
     #define BZ_DEBUG_MESSAGE(X)                                          \
@@ -138,7 +138,7 @@ _bz_global int  assertSuccessCount BZ_GLOBAL_INIT(0);
         }
 
     #define BZ_DEBUG_PARAM(X) X
-    #define BZ_PRE_FAIL        checkAssert(0)
+    #define BZ_PRE_FAIL        blitz::checkAssert(0)
     #define BZ_ASM_DEBUG_MARKER
 
 #elif defined(BZ_DEBUG)

--- a/blitz/generate/genstencils.py
+++ b/blitz/generate/genstencils.py
@@ -104,7 +104,7 @@ def BZ_ET_STENCIL(name, result, etresult, MINB, MAXB):
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return iter_.fastRead_tv<N>(i); }
+      return iter_.template fastRead_tv<N>(i); }
       
     T_result shift(int offset, int dim) const				
     {									
@@ -451,7 +451,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return iter_.fastRead_tv<N>(i); }
+      return iter_.template fastRead_tv<N>(i); }
      									
   T_result shift(int offset, int dim) const				
   {									
@@ -590,7 +590,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return iter_.fastRead_tv<N>(i); }
+      return iter_.template fastRead_tv<N>(i); }
 
   T_numtype shift(int offset, int dim) const				
   {									
@@ -728,7 +728,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return iter_.fastRead_tv<N>(i); }
+      return iter_.template fastRead_tv<N>(i); }
 
   T_numtype shift(int offset, int dim) const				
   {									
@@ -871,7 +871,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return typename tvresult<N>::Type(iter_.fastRead_tv<N>(i),dim_); }
+      return typename tvresult<N>::Type(iter_.template fastRead_tv<N>(i),dim_); }
 
   T_result shift(int offset, int dim) const				
   {									
@@ -1023,7 +1023,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return typename tvresult<N>::Type(iter_.fastRead_tv<N>(i),comp_,dim_); }
+      return typename tvresult<N>::Type(iter_.template fastRead_tv<N>(i),comp_,dim_); }
 
   T_numtype shift(int offset, int dim) const				
   {									
@@ -1184,7 +1184,7 @@ public:
     template<int N>
     typename tvresult<N>::Type fastRead_tv(diffType i) const {
       BZPRECHECK(0, "Can't vectorize stencils");
-      return typename tvresult<N>::Type(iter_.fastRead_tv<N>(i),dim1_,dim2_); }
+      return typename tvresult<N>::Type(iter_.template fastRead_tv<N>(i),dim1_,dim2_); }
 
   T_numtype shift(int offset, int dim) const				
   {									

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,14 +7,14 @@ EXTRA_DIST = stencil4.f profile.cpp tiny2.cpp tiny3.cpp
 AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir) -I$(top_builddir) $(BOOST_CPPFLAGS)
 LDADD = -L$(top_builddir)/lib -lblitz 
 
-EXTRA_PROGRAMS = array cartesian cast complex-test convolve \
+EXTRA_PROGRAMS = arrayx cartesian cast complex-test convolve \
 deriv fixed io iter matmult nested numinquire outer \
 polymorph prettyprint rand2 random reduce simple \
 slicing stencil2 storage tiny \
 useret where whitt 
 # cfd curldiv diff erf indirect pauli pick qcd rangexpr stencil3 stencil stencilet transform 
 
-array_SOURCES = array.cpp
+arrayx_SOURCES = array.cpp
 cartesian_SOURCES = cartesian.cpp
 cast_SOURCES = cast.cpp
 #cfd_SOURCES = cfd.cpp

--- a/examples/numinquire.cpp
+++ b/examples/numinquire.cpp
@@ -31,7 +31,7 @@ int main()
          << endl;
 
     cout << endl << "More obscure properties:" << endl
-         << "is_signed(z) = " << is_signed(z) << endl
+         << "is_signed(z) = " << blitz::is_signed(z) << endl
          << "is_integer(z) = " << is_integer(z) << endl
          << "is_exact(z) = " << is_exact(z) << endl
          << "round_error(z) = " << round_error(z) << endl

--- a/m4/ac_cxx_flags_preset.m4
+++ b/m4/ac_cxx_flags_preset.m4
@@ -47,7 +47,7 @@ if test "$enableval" = yes ; then
 		CXX_VENDOR="LLVM"
 		CXXFLAGS="-ansi"
 		CXX_OPTIMIZE_FLAGS="-O3"
-		CXX_DEBUG_FLAGS="-g -O0 -C -DBZ_DEBUG"
+		CXX_DEBUG_FLAGS="-g -O0 -DBZ_DEBUG"
 		CXX_PROFIL_FLAGS="-pg"
 	;;
 	*icpc*|*icc*) dnl Intel icc http://www.intel.com/


### PR DESCRIPTION
I needed Blitz on my Mac with CLang compilers.  The testsuite and examples tests build and run for me with the following compilers:
- Mac OS X, Sierra, Apple CLang (XCode 8.3.3)
- Mac OS X, Sierra, CLang 3.8 (MacPorts)
- Mac OSX, Sierra, GNU 5.4 and 6.3
- RHEL7, GNU 4.8, 5.4 and 6.3
- RHEL6, Intel 15 and 17
- RHEL6, GNU 4.4
