### PR TITLE
Fix version number in the build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 
 AC_PREREQ(2.59)
 
-AC_INIT(blitz, 0.10, blitz-support@lists.sourceforge.net)
+AC_INIT(blitz, 1.0.2, blitz-support@lists.sourceforge.net)
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
The build system should contain the same version number as the release tarball, otherwise confusion will arise.