### PR TITLE
Use python2 command because we are NOT Python3 compatible.

### DIFF
--- a/blitz/generate/Makefile.am
+++ b/blitz/generate/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = genstencils.py
 EXTRA_PROGRAMS = 
 
 $(top_srcdir)/blitz/array/stencil-classes.cc: genstencils.py
-	python $< $@
+	python2 $< $@
 
 generate-headers: $(top_srcdir)/blitz/array/stencil-classes.cc
 

--- a/blitz/generate/genstencils.py
+++ b/blitz/generate/genstencils.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python2
 
 # Generates stencil code. This replaces the macros in stencil-et.h,
 # which make it impossible to debug the generated code.

--- a/blitz/generate/makeloops.py
+++ b/blitz/generate/makeloops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # python version of the makeloops.cpp that generates the benchmark
 # loops.


### PR DESCRIPTION
By default, `python` is supposed to mean only Python2.  Some distros link `python -> python3`, causing problems for older scripts that assume Python2.  If you need Python2, you should use the command `python2`.

See https://github.com/spack/spack/pull/7960
