### PR TITLE
Add future print_function for python2 and python3 compatibility

### DIFF
--- a/blitz/generate/genstencils.py
+++ b/blitz/generate/genstencils.py
@@ -3,10 +3,12 @@
 # Generates stencil code. This replaces the macros in stencil-et.h,
 # which make it impossible to debug the generated code.
 
+from __future__ import print_function
+
 import sys
 
 os=open(sys.argv[1],'w')
-print "Generating file %s"%sys.argv[1]
+print("Generating file %s"%sys.argv[1])
 
 def BZ_ET_STENCIL_REDIRECT(name):
     stub="""

--- a/blitz/generate/makeloops.py
+++ b/blitz/generate/makeloops.py
@@ -3,6 +3,8 @@
 # python version of the makeloops.cpp that generates the benchmark
 # loops.
 
+from __future__ import print_function
+
 import time, pdb
 
 # definitions of the loops (from loops.data)


### PR DESCRIPTION
Tested using Python 3.6.0 in Anaconda 4.3.1 environment.