### PR TITLE
Drop obsolete Texinfo command

### DIFF
--- a/doc/blitz.texi
+++ b/doc/blitz.texi
@@ -6,7 +6,6 @@
 @setchapternewpage odd
 @finalout
 @iftex
-@setcontentsaftertitlepage
 @afourpaper
 @end iftex
 @c %**end of header


### PR DESCRIPTION
Description: upstream source: doc: drop obsolete Texinfo command
 @setcontentsaftertitlepage has been removed from Texinfo: see email
 https://lists.gnu.org/archive/html/bug-texinfo/2016-02/msg00015.html
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2018-08-25