### PR TITLE
Add option to zero-initialize new elements created by resizeAndPreserve.

### DIFF
--- a/blitz/array-impl.h
+++ b/blitz/array-impl.h
@@ -1107,41 +1107,53 @@ public:
  
 
     void                              resizeAndPreserve(const TinyVector<int,
-                                                                   N_rank>&);
-    void                              resizeAndPreserve(int extent);
+                                        N_rank>&,
+                                        bool zeroInitialize=false);
+    void                              resizeAndPreserve(int extent,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1, 
-                                        int extent2);
+                                        int extent2,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1, 
-                                        int extent2, int extent3);
-    void                              resizeAndPreserve(int extent1,
-                                        int extent2, int extent3, int extent4);
-    void                              resizeAndPreserve(int extent1,
-                                        int extent2, int extent3, int extent4,
-                                        int extent5);
+                                        int extent2, int extent3,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
-                                        int extent5, int extent6);
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
-                                        int extent5, int extent6, int extent7);
+                                        int extent5,
+                                        bool zeroInitialize=false);
+    void                              resizeAndPreserve(int extent1,
+                                        int extent2, int extent3, int extent4,
+                                        int extent5, int extent6,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
                                         int extent5, int extent6, int extent7,
-                                        int extent8);
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
                                         int extent5, int extent6, int extent7,
-                                        int extent8, int extent9);
+                                        int extent8,
+                                        bool zeroInitialize=false);
+    void                              resizeAndPreserve(int extent1,
+                                        int extent2, int extent3, int extent4,
+                                        int extent5, int extent6, int extent7,
+                                        int extent8, int extent9,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
                                         int extent5, int extent6, int extent7,
                                         int extent8, int extent9, 
-                                        int extent10);
+                                        int extent10,
+                                        bool zeroInitialize=false);
     void                              resizeAndPreserve(int extent1,
                                         int extent2, int extent3, int extent4,
                                         int extent5, int extent6, int extent7,
                                         int extent8, int extent9, int extent10,
-                                        int extent11);
+                                        int extent11,
+                                        bool zeroInitialize=false);
 
     // NEEDS_WORK -- resizeAndPreserve(Range,...)
     // NEEDS_WORK -- resizeAndPreserve(const Domain<N_rank>&);

--- a/blitz/array/resize.cc
+++ b/blitz/array/resize.cc
@@ -567,7 +567,8 @@ void Array<T_numtype, N_rank>::resize(Range r0, Range r1, Range r2,
 
 
 template<typename T_numtype, int N_rank>
-void Array<T_numtype, N_rank>::resizeAndPreserve(int length0)
+void Array<T_numtype, N_rank>::resizeAndPreserve(int length0,
+    bool zeroInitialize)
 {
     BZPRECONDITION(length0 > 0);
     BZPRECONDITION(N_rank == 1);
@@ -595,6 +596,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0)
 #endif
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
               ubound(0)));
             B(overlap0) = (*this)(overlap0);
@@ -604,7 +607,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0)
 }
 
 template<typename T_numtype, int N_rank>
-void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1)
+void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
+    bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0));
     BZPRECONDITION(N_rank == 2);
@@ -615,6 +619,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1)
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                 ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -627,7 +633,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1)
 
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
-    int length2)
+    int length2, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0));
     BZPRECONDITION(N_rank == 3);
@@ -639,6 +645,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
             storage_);
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                 ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -654,7 +662,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
-    int length2, int length3)
+    int length2, int length3, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0));
@@ -668,6 +676,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), ubound(1)));
             Range overlap2 = Range(fromStart, (extrema::min)(B.ubound(2), ubound(2)));
@@ -681,7 +691,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
-    int length2, int length3, int length4)
+    int length2, int length3, int length4, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0));
@@ -696,6 +706,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), ubound(1)));
             Range overlap2 = Range(fromStart, (extrema::min)(B.ubound(2), ubound(2)));
@@ -710,7 +722,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
-    int length2, int length3, int length4, int length5)
+    int length2, int length3, int length4, int length5,
+    bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0));
@@ -725,6 +738,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), ubound(1)));
             Range overlap2 = Range(fromStart, (extrema::min)(B.ubound(2), ubound(2)));
@@ -742,7 +757,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 /* Added by Julian Cummings */
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
-    int length2, int length3, int length4, int length5, int length6)
+    int length2, int length3, int length4, int length5, int length6,
+    bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0) && (length6 > 0));
@@ -758,6 +774,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -785,7 +803,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
     int length2, int length3, int length4, int length5, int length6,
-    int length7)
+    int length7, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0) && (length6 > 0)
@@ -802,6 +820,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -831,7 +851,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
     int length2, int length3, int length4, int length5, int length6,
-    int length7, int length8)
+    int length7, int length8, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0) && (length6 > 0)
@@ -849,6 +869,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -880,7 +902,7 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
     int length2, int length3, int length4, int length5, int length6,
-    int length7, int length8, int length9)
+    int length7, int length8, int length9, bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0) && (length6 > 0)
@@ -899,6 +921,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -932,7 +956,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
     int length2, int length3, int length4, int length5, int length6,
-    int length7, int length8, int length9, int length10)
+    int length7, int length8, int length9, int length10,
+    bool zeroInitialize)
 {
     BZPRECONDITION((length0 > 0) && (length1 > 0) && (length2 > 0)
         && (length3 > 0) && (length4 > 0) && (length5 > 0) && (length6 > 0)
@@ -952,6 +977,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(int length0, int length1,
 
         if (numElements())
         {
+            if (zeroInitialize)
+                B = 0;
             Range overlap0 = Range(fromStart, (extrema::min)(B.ubound(0), 
                ubound(0)));
             Range overlap1 = Range(fromStart, (extrema::min)(B.ubound(1), 
@@ -998,7 +1025,7 @@ void Array<T_numtype, N_rank>::resize(const TinyVector<int,N_rank>& extent)
 /* Added by Julian Cummings */
 template<typename T_numtype, int N_rank>
 void Array<T_numtype, N_rank>::resizeAndPreserve(
-    const TinyVector<int,N_rank>& extent)
+    const TinyVector<int,N_rank>& extent, bool zeroInitialize)
 {
 // NEEDS_WORK -- don't resize if unnecessary
 //    BZPRECONDITION(all(extent > 0));
@@ -1008,6 +1035,8 @@ void Array<T_numtype, N_rank>::resizeAndPreserve(
 
         if (numElements())
         {
+          if (zeroInitialize)
+            B = 0;
           TinyVector<int,N_rank> ub;
           for (int d=0; d < N_rank; ++d)
             ub(d) = (extrema::min)(B.ubound(d),ubound(d));

--- a/doc/arrays-members.texi
+++ b/doc/arrays-members.texi
@@ -429,7 +429,7 @@ the contents of the array are garbage.  See also @code{resizeAndPreserve()}.
 @findex resizeAndPreserve()
 @cindex Array member functions @code{resizeAndPreserve()}
 @example
-void                              resizeAndPreserve(int extent1, ...);
+void                              resizeAndPreserve(int extent1, ..., bool zeroInitialize=false);
 void                              resizeAndPreserve(const TinyVector<int,N_rank>&);
 @end example
 
@@ -437,7 +437,8 @@ These functions resize an array to the specified size.  If the array is
 already the size specified, then no change occurs (the array is not
 reallocated and copied).  The contents of the array are preserved whenever
 possible; if the new array size is smaller, then some data will be lost.
-Any new elements created by resizing the array are left uninitialized.
+Any new elements created by resizing the array are left uninitialized
+unless zeroInitialize is set to true.
 
 @findex reverse(), reverseSelf()
 @cindex Array member functions @code{reverse()}

--- a/manual/arrays-members.yo
+++ b/manual/arrays-members.yo
@@ -417,7 +417,7 @@ garbage.  See also tt(resizeAndPreserve()).
 bzindex(resizeAndPreserve())
 bzindex(Array!member functions!resizeAndPreserve())
 bf(bzverb(\
-void                              resizeAndPreserve(int extent1, ...);
+void                              resizeAndPreserve(int extent1, ..., bool zeroInitialize=false);
 void                              resizeAndPreserve(const TinyVector<int,N_rank>&)));
 These functions resize an array to the specified size.  If
 the array is already the size specified, then no change
@@ -425,7 +425,7 @@ occurs (the array is not reallocated and copied).
 The contents of the array are preserved whenever possible;
 if the new array size is smaller, then some data will be
 lost.  Any new elements created by resizing the array
-are left uninitialized.
+are left uninitialized unless zeroInitialize is set to true.
 
 bzindex(reverse(), reverseSelf())
 bzindex(Array!member functions!reverse())

--- a/manual/blitz02.html
+++ b/manual/blitz02.html
@@ -1151,7 +1151,7 @@ allocated.  After resizing, the contents of the array are
 garbage.  See also <code>resizeAndPreserve()</code>.
 <p><!-- BZINDEX resizeAndPreserve() --><a name="index00174">
 <!-- BZINDEX Array!member functions!resizeAndPreserve() --><a name="index00175">
-<strong><pre>void                              resizeAndPreserve(int extent1, ...);
+<strong><pre>void                              resizeAndPreserve(int extent1, ..., bool zeroInitialize=false);
 void                              resizeAndPreserve(const TinyVector&lt;int,N_rank&gt;&amp;)</pre></strong>;
 These functions resize an array to the specified size.  If
 the array is already the size specified, then no change
@@ -1159,7 +1159,7 @@ occurs (the array is not reallocated and copied).
 The contents of the array are preserved whenever possible;
 if the new array size is smaller, then some data will be
 lost.  Any new elements created by resizing the array
-are left uninitialized.
+are left uninitialized unless zeroInitialize is set to true.
 <p><!-- BZINDEX reverse(), reverseSelf() --><a name="index00176">
 <!-- BZINDEX Array!member functions!reverse() --><a name="index00177">
 <!-- BZINDEX Array!member functions!reverseSelf() --><a name="index00178">


### PR DESCRIPTION
I found it useful to have new elements of an array created by resizeAndPreserve zero-initialize on request. For example when performing FFT interpolation. This can be a bit of a pain to do after the fact because multiple regions could need to be zeroed. I suppose this behavior could also be achieved externally to the library by re-implementing most of what resizeAndPreserve currently does.

Testing: passes "make check-testsuite".

Updated documentation.

Grateful for any feedback.