### PR TITLE
Activate static lib under Windows + generate import library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ set_target_properties(blitz PROPERTIES
                       VERSION ${blitz_VERSION}
                       SOVERSION 0
                       CLEAN_DIRECT_OUTPUT 1)
-if (WIN32)
+if (WIN32 AND NOT MINGW)
 	set_target_properties(blitz PROPERTIES
 						  IMPORT_SUFFIX ".dll.lib")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,17 +23,21 @@ set_target_properties(blitz PROPERTIES
                       VERSION ${blitz_VERSION}
                       SOVERSION 0
                       CLEAN_DIRECT_OUTPUT 1)
+if (WIN32)
+	set_target_properties(blitz PROPERTIES
+						  IMPORT_SUFFIX ".dll.lib")
+endif()
 
 set(BLITZ_LIBS blitz)
-if (NOT WIN32)
-    add_library(blitz-static STATIC ${blitz_LIB_SRCS})
-    add_dependencies(blitz-static generated-headers)
-    set(BLITZ_LIBS ${BLITZ_LIBS} blitz-static)
-    set_target_properties(blitz-static PROPERTIES
-                          OUTPUT_NAME blitz
-                          ${BLITZ-STATIC-DEFS}
-                          CLEAN_DIRECT_OUTPUT 1)
-endif()
+
+add_library(blitz-static STATIC ${blitz_LIB_SRCS})
+add_dependencies(blitz-static generated-headers)
+set(BLITZ_LIBS ${BLITZ_LIBS} blitz-static)
+set_target_properties(blitz-static PROPERTIES
+					  OUTPUT_NAME blitz
+					  ${BLITZ-STATIC-DEFS}
+					  CLEAN_DIRECT_OUTPUT 1)
+
 
 install(TARGETS ${BLITZ_LIBS}
         EXPORT  ${PROJECT_NAME}Targets


### PR DESCRIPTION
I have modified the CMakeLists.txt to generate static library under Windows (MinGW and MSVC) and and specify the import library suffix to ensure thaht it not overwrited by static one.

Tested under MinGW-w64 with GCC 9.3.0 and MSVC 14.24 (VS2019)